### PR TITLE
fix(server): Correct start script for Railway deployment

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -5,11 +5,11 @@
   "license": "ISC",
   "author": "",
   "type": "module",
-  "main": "server.ts",
+  "main": "dist/server.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "build": "tsc",
-    "start": "npm run build && node dist/index.js"
+    "start": "npm run build && node dist/server.js"
   },
   "dependencies": {
     "cors": "^2.8.5",


### PR DESCRIPTION
The server failed to start on Railway because the 'start' script in package.json was pointing to a non-existent file (dist/index.js) after the build process.

This commit corrects the path in the 'start' script to point to the correct compiled entry file, `dist/server.js`. The 'main' field in package.json has also been updated for consistency.